### PR TITLE
feat: introduce openai-based MAPE-K agents

### DIFF
--- a/llm_agents/openai_approval_agents.py
+++ b/llm_agents/openai_approval_agents.py
@@ -1,0 +1,153 @@
+"""OpenAI based implementations of approval and streaming agents.
+
+These agents replace the previous llamaindex based variants and use the
+OpenAI ``responses`` API directly.  They keep structured output via the
+Pydantic models defined in :mod:`llm_agents.models` and support streaming
+of the final response.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional, Callable, Any
+
+from openai import AsyncOpenAI
+
+from llm_agents.models import (
+    PlanExecuteResultModel,
+    PlanApprovalExecuteResultModel,
+)
+from llm_agents.openai_prompts import (
+    format_plan_execute_prompt,
+    format_plan_approval_execute_prompt,
+)
+
+StreamCallback = Optional[Callable[[str, bool], None]]
+
+
+class MapeKApprovalBaseAgent:
+    """Adaptive MAPE-K agent using the OpenAI API only.
+
+    The agent starts without an explanation plan.  For the first user
+    question it creates a plan and executes it in one step.  For follow up
+    questions it asks the model to approve or modify the plan before
+    executing the next explanation step.
+    """
+
+    def __init__(self, client: Optional[AsyncOpenAI] = None, *, model: Optional[str] = None):
+        self.client = client or AsyncOpenAI()
+        self.model = model or os.getenv("OPENAI_MODEL_NAME", "gpt-4o-mini")
+
+        # Conversation state
+        self.context: str = ""
+        self.explanation_collection: str = ""
+        self.user_model: str = ""
+        self.explanation_plan: list[Any] = []
+        self.last_shown_explanations: str = ""
+        self.history: str = ""
+
+    # ------------------------------------------------------------------
+    # Initialisation helpers
+    # ------------------------------------------------------------------
+    def initialize_new_datapoint(
+        self,
+        *,
+        context: str,
+        explanation_collection: str,
+        user_model: str = "",
+        explanation_plan: Optional[list[Any]] = None,
+        last_shown_explanations: str = "",
+    ) -> None:
+        """Seed the agent with the information about a new datapoint."""
+        self.context = context
+        self.explanation_collection = explanation_collection
+        self.user_model = user_model
+        self.explanation_plan = explanation_plan or []
+        self.last_shown_explanations = last_shown_explanations
+        self.history = ""
+
+    # ------------------------------------------------------------------
+    async def _run_llm(
+        self,
+        prompt: str,
+        response_model: type,
+        *,
+        stream: bool = False,
+        callback: StreamCallback = None,
+    ) -> Any:
+        """Execute the prompt and parse the structured output."""
+        if not stream:
+            resp = await self.client.responses.parse(
+                model=self.model,
+                input=prompt,
+                response_format=response_model,
+            )
+            return resp.output[0].parsed
+
+        stream_resp = await self.client.responses.stream(
+            model=self.model,
+            input=prompt,
+            response_format=response_model,
+        )
+        async for event in stream_resp:
+            if event.type == "response.output_text.delta" and callback:
+                callback(event.delta, False)
+        if callback:
+            callback("", True)
+        final = await stream_resp.get_final_response()
+        return final.output[0].parsed
+
+    # ------------------------------------------------------------------
+    async def answer_user_question(
+        self,
+        user_message: str,
+        *,
+        stream: bool = False,
+        callback: StreamCallback = None,
+    ) -> Any:
+        """Answer the user's question using plan approval when needed."""
+        prompt_args = dict(
+            context=self.context,
+            explanation_collection=self.explanation_collection,
+            explanation_plan="\n".join(
+                f"{p.explanation_name}:{p.step_name}" for p in self.explanation_plan
+            ),
+            user_model=self.user_model,
+            last_shown_explanations=self.last_shown_explanations,
+            history=self.history,
+            user_message=user_message,
+        )
+        if not self.explanation_plan:
+            prompt = format_plan_execute_prompt(**prompt_args)
+            model_cls = PlanExecuteResultModel
+        else:
+            prompt = format_plan_approval_execute_prompt(**prompt_args)
+            model_cls = PlanApprovalExecuteResultModel
+
+        result = await self._run_llm(prompt, model_cls, stream=stream, callback=callback)
+
+        # Update conversation state
+        self.history += f"\nUser: {user_message}\nAgent: {getattr(result, 'response', '')}"
+        if isinstance(result, PlanExecuteResultModel) and result.explanation_plan:
+            self.explanation_plan = result.explanation_plan
+        if isinstance(result, PlanApprovalExecuteResultModel) and result.next_response:
+            # prepend alternative step if plan was modified
+            if not result.approved:
+                self.explanation_plan.insert(0, result.next_response)
+            else:
+                # remove approved step that has been executed
+                if self.explanation_plan:
+                    self.explanation_plan.pop(0)
+        return result
+
+
+class ConversationalStreamAgent(MapeKApprovalBaseAgent):
+    """Variant of :class:`MapeKApprovalBaseAgent` that streams output."""
+
+    async def answer_user_question(
+        self, user_message: str, *, callback: StreamCallback
+    ) -> Any:  # pragma: no cover - thin wrapper
+        return await super().answer_user_question(
+            user_message, stream=True, callback=callback
+        )
+

--- a/llm_agents/openai_prompts.py
+++ b/llm_agents/openai_prompts.py
@@ -1,0 +1,89 @@
+"""OpenAI-specific prompt templates without llama-index dependencies.
+
+This module provides minimal prompt templates for MAPE-K agents that
+previously relied on the llamaindex ``PromptMixin`` utilities.  The
+templates keep the same placeholder names so existing context building
+code can be reused.
+"""
+
+from typing import Any
+
+PLAN_EXECUTE_PROMPT = """
+You are an Adaptive XAI Planner & Communicator: you craft coherent
+explanation plans tailored to the user's cognitive state and machine
+learning expertise, then deliver the next content in concise,
+engaging responses.
+
+<context>
+{context}
+</context>
+<explanation_collection>
+{explanation_collection}
+</explanation_collection>
+<previous_plan>
+{explanation_plan}
+</previous_plan>
+<user_model>
+{user_model}
+</user_model>
+<last_shown_explanations>
+{last_shown_explanations}
+</last_shown_explanations>
+<conversation_history>
+{history}
+</conversation_history>
+<user_message>
+{user_message}
+</user_message>
+<task>
+  <objective>Plan and Execute</objective>
+  <instructions>First propose any new explanations and update the
+  explanation plan. Then craft the user facing response using at most
+  four sentences.</instructions>
+</task>
+"""
+
+PLAN_APPROVAL_EXECUTE_PROMPT = """
+You are an Adaptive XAI Plan Evaluator.  Assess whether the existing
+explanation plan still fits the user's needs and either approve it or
+modify it before answering the user.
+
+<context>
+{context}
+</context>
+<explanation_collection>
+{explanation_collection}
+</explanation_collection>
+<user_model>
+{user_model}
+</user_model>
+<previous_plan>
+{explanation_plan}
+</previous_plan>
+<last_shown_explanations>
+{last_shown_explanations}
+</last_shown_explanations>
+<conversation_history>
+{history}
+</conversation_history>
+<user_message>
+{user_message}
+</user_message>
+<task>
+  <objective>Plan Approval and Execute</objective>
+  <instructions>Decide if the next planned step should be executed.
+  If not, pick a better next step.  Then respond to the user in at
+  most four sentences.</instructions>
+</task>
+"""
+
+
+def format_plan_execute_prompt(**kwargs: Any) -> str:
+    """Format the Plan+Execute prompt with the given keyword arguments."""
+    return PLAN_EXECUTE_PROMPT.format(**kwargs)
+
+
+def format_plan_approval_execute_prompt(**kwargs: Any) -> str:
+    """Format the PlanApproval+Execute prompt with the given keyword arguments."""
+    return PLAN_APPROVAL_EXECUTE_PROMPT.format(**kwargs)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,14 +8,6 @@ gin-config==0.5.0
 gunicorn==23.0.0
 gevent==24.11.1
 lime==0.2.0.1
-llama-index==0.12.33
-llama-index-agent-openai==0.4.6
-llama-index-cli==0.4.1
-llama-index-core==0.12.33.post1
-llama-index-embeddings-openai==0.3.1
-llama-index-llms-openai==0.3.38
-llama-index-program-openai==0.3.1
-llama-index-utils-workflow==0.3.1
 matplotlib==3.7.0
 mlflow==3.1.0
 numpy>=1.23.5,<2.0.0


### PR DESCRIPTION
## Summary
- add OpenAI-only approval and streaming agents
- provide lightweight prompt templates without llamaindex
- drop llamaindex dependencies from requirements

## Testing
- `python -m py_compile llm_agents/openai_prompts.py llm_agents/openai_approval_agents.py`


------
https://chatgpt.com/codex/tasks/task_e_689bbb246a3083328485b8d329181b06